### PR TITLE
Make getMediaStream work when occupant hasn't been created yet.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,9 @@ class JanusAdapter {
 
     this.publisher = null;
     this.occupants = {};
-    this.occupantPromises = {};
+    this.occupantPeerConnections = {};
+    this.audioStreams = {};
+    this.pendingAudioRequests = {};
 
     this.onWebsocketMessage = this.onWebsocketMessage.bind(this);
     this.onDataChannelMessage = this.onDataChannelMessage.bind(this);
@@ -86,16 +88,21 @@ class JanusAdapter {
     // Attach the SFU Plugin and create a RTCPeerConnection for the publisher.
     // The publisher sends audio and opens two bidirectional data channels.
     // One reliable datachannel and one unreliable.
-    var publisherPromise = this.createPublisher();
-    this.occupantPromises[this.userId] = publisherPromise;
-    this.publisher = await publisherPromise;
+    this.publisher = await this.createPublisher();
 
-    this.connectSuccess(this.userId);
+    this.audioStreams[this.userId] = this.publisher.mediaStream;
+
+    // Resolve the promise for the user's media stream if it exists.
+    if (this.pendingAudioRequests[this.userId]) {
+      this.pendingAudioRequests[this.userId].resolve(
+        this.publisher.mediaStream
+      );
+    }
 
     // Add all of the initial occupants.
     for (let occupantId of this.publisher.initialOccupants) {
       if (occupantId !== this.userId) {
-        this.occupantPromises[occupantId] = this.addOccupant(occupantId);
+        this.addOccupant(occupantId);
       }
     }
   }
@@ -108,7 +115,7 @@ class JanusAdapter {
     if (message.plugindata && message.plugindata.data) {
       var data = message.plugindata.data;
       if (data.event === "join" && data.room_id === this.room) {
-        this.occupantPromises[data.user_id] = this.addOccupant(data.user_id);
+        this.addOccupant(data.user_id);
       } else if (
         data.event &&
         data.event === "leave" &&
@@ -125,16 +132,44 @@ class JanusAdapter {
 
   async addOccupant(occupantId) {
     var subscriber = await this.createSubscriber(occupantId);
+
+    this.occupants[occupantId] = true;
+    this.occupantPeerConnections[occupantId] = subscriber.peerConnection;
+    this.audioStreams[occupantId] = subscriber.mediaStream;
+
+    // Resolve the promise for the user's media stream if it exists.
+    if (this.pendingAudioRequests[occupantId]) {
+      this.pendingAudioRequests[occupantId].resolve(subscriber.mediaStream);
+    }
+
     // Call the Networked AFrame callbacks for the new occupant.
     this.onOccupantConnected(occupantId);
-    this.occupants[occupantId] = true;
     this.onOccupantsChanged(this.occupants);
+
     return subscriber;
   }
 
   removeOccupant(occupantId) {
     if (this.occupants[occupantId]) {
+      // Close the subscriber peer connection. Which also detaches the plugin handle.
+      if (this.occupantPeerConnections[occupantId]) {
+        this.occupantPeerConnections[occupantId].close();
+        delete this.occupantPeerConnections[occupantId];
+      }
+
+      if (this.audioStreams[occupantId]) {
+        delete this.audioStreams[occupantId];
+      }
+
+      if (this.pendingAudioRequests[occupantId]) {
+        this.pendingAudioRequests[occupantId].reject(
+          "The user disconnected before the media stream was resolved."
+        );
+        delete this.pendingAudioRequests[occupantId];
+      }
+
       delete this.occupants[occupantId];
+
       // Call the Networked AFrame callbacks for the removed occupant.
       this.onOccupantDisconnected(occupantId);
       this.onOccupantsChanged(this.occupants);
@@ -209,6 +244,15 @@ class JanusAdapter {
     debug("pub waiting for webrtcup");
     await this.getWebRtcUpPromise(handle.id).promise;
 
+    if (reliableChannel.readyState !== "open") {
+      debug("pub waiting for channel to open");
+      // Wait for the reliable datachannel to be open before we start sending messages on it.
+      await waitForEvent(reliableChannel, "open");
+    }
+
+    // Call the naf connectSuccess callback before we start receiving WebRTC messages.
+    this.connectSuccess(this.userId);
+
     debug("pub waiting for join");
     // Send join message to janus. Listen for join/leave messages. Automatically subscribe to all users' WebRTC data.
     var message = await this.sendJoin(handle, this.room, this.userId, {
@@ -217,12 +261,6 @@ class JanusAdapter {
     });
 
     var initialOccupants = message.plugindata.data.response.users[this.room];
-
-    if (reliableChannel.readyState !== "open") {
-      debug("pub waiting for channel to open");
-      // Wait for the reliable datachannel to be open before we start sending messages on it.
-      await waitForEvent(reliableChannel, "open");
-    }
 
     debug("publisher ready");
     return {
@@ -328,15 +366,15 @@ class JanusAdapter {
   }
 
   getMediaStream(clientId) {
-    var occupantPromise = this.occupantPromises[clientId];
-
-    if (!occupantPromise) {
-      return Promise.reject(
-        new Error(`Subscriber for client: ${clientId} does not exist.`)
-      );
+    if (this.audioStreams[clientId]) {
+      NAF.log.write("Already had audio for " + clientId);
+      return Promise.resolve(this.audioStreams[clientId]);
+    } else {
+      NAF.log.write("Waiting on audio for " + clientId);
+      return new Promise((resolve, reject) => {
+        this.pendingAudioRequests[clientId] = { resolve, reject };
+      });
     }
-
-    return occupantPromise.then(s => s.mediaStream);
   }
 
   setLocalMediaStream(stream) {

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,8 @@ class JanusAdapter {
     this.publisher = null;
     this.occupants = {};
     this.occupantPeerConnections = {};
-    this.audioStreams = {};
-    this.pendingAudioRequests = {};
+    this.mediaStreams = {};
+    this.pendingMediaRequests = {};
 
     this.onWebsocketMessage = this.onWebsocketMessage.bind(this);
     this.onDataChannelMessage = this.onDataChannelMessage.bind(this);
@@ -90,11 +90,11 @@ class JanusAdapter {
     // One reliable datachannel and one unreliable.
     this.publisher = await this.createPublisher();
 
-    this.audioStreams[this.userId] = this.publisher.mediaStream;
+    this.mediaStreams[this.userId] = this.publisher.mediaStream;
 
     // Resolve the promise for the user's media stream if it exists.
-    if (this.pendingAudioRequests[this.userId]) {
-      this.pendingAudioRequests[this.userId].resolve(
+    if (this.pendingMediaRequests[this.userId]) {
+      this.pendingMediaRequests[this.userId].resolve(
         this.publisher.mediaStream
       );
     }
@@ -135,11 +135,11 @@ class JanusAdapter {
 
     this.occupants[occupantId] = true;
     this.occupantPeerConnections[occupantId] = subscriber.peerConnection;
-    this.audioStreams[occupantId] = subscriber.mediaStream;
+    this.mediaStreams[occupantId] = subscriber.mediaStream;
 
     // Resolve the promise for the user's media stream if it exists.
-    if (this.pendingAudioRequests[occupantId]) {
-      this.pendingAudioRequests[occupantId].resolve(subscriber.mediaStream);
+    if (this.pendingMediaRequests[occupantId]) {
+      this.pendingMediaRequests[occupantId].resolve(subscriber.mediaStream);
     }
 
     // Call the Networked AFrame callbacks for the new occupant.
@@ -157,15 +157,15 @@ class JanusAdapter {
         delete this.occupantPeerConnections[occupantId];
       }
 
-      if (this.audioStreams[occupantId]) {
-        delete this.audioStreams[occupantId];
+      if (this.mediaStreams[occupantId]) {
+        delete this.mediaStreams[occupantId];
       }
 
-      if (this.pendingAudioRequests[occupantId]) {
-        this.pendingAudioRequests[occupantId].reject(
+      if (this.pendingMediaRequests[occupantId]) {
+        this.pendingMediaRequests[occupantId].reject(
           "The user disconnected before the media stream was resolved."
         );
-        delete this.pendingAudioRequests[occupantId];
+        delete this.pendingMediaRequests[occupantId];
       }
 
       delete this.occupants[occupantId];
@@ -366,13 +366,13 @@ class JanusAdapter {
   }
 
   getMediaStream(clientId) {
-    if (this.audioStreams[clientId]) {
-      NAF.log.write("Already had audio for " + clientId);
-      return Promise.resolve(this.audioStreams[clientId]);
+    if (this.mediaStreams[clientId]) {
+      debug("Already had audio for " + clientId);
+      return Promise.resolve(this.mediaStreams[clientId]);
     } else {
-      NAF.log.write("Waiting on audio for " + clientId);
+      debug("Waiting on audio for " + clientId);
       return new Promise((resolve, reject) => {
-        this.pendingAudioRequests[clientId] = { resolve, reject };
+        this.pendingMediaRequests[clientId] = { resolve, reject };
       });
     }
   }


### PR DESCRIPTION
Similar to how @netpro2k handled this in the [EasyRTCAdapter](https://github.com/networked-aframe/networked-aframe/blob/master/src/adapters/EasyRtcAdapter.js#L142).

Also added some additional work to correctly dispose of an occupant's mediastream and peer connection.