### PR TITLE
Don't use date header if it's null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -313,12 +313,16 @@ class JanusAdapter {
     });
 
     const precision = 1000;
-    const serverReceivedTime =
-      new Date(res.headers.get("Date")).getTime() + precision / 2;
-    const clientReceivedTime = Date.now();
-    const serverTime =
-      serverReceivedTime + (clientReceivedTime - clientSentTime) / 2;
-    const timeOffset = serverTime - clientReceivedTime;
+    const serverDate = res.headers.get("Date");
+    let timeOffset = 0;
+    if (serverDate) {
+      const serverReceivedTime =
+        new Date(serverDate).getTime() + precision / 2;
+      const clientReceivedTime = Date.now();
+      const serverTime =
+        serverReceivedTime + (clientReceivedTime - clientSentTime) / 2;
+      timeOffset = serverTime - clientReceivedTime;
+    }
 
     this.serverTimeRequests++;
 


### PR DESCRIPTION
Noticed that I was getting very wrong serverTimes when testing locally. Seems like webpack-dev-server doesn't set the date in header, at least on the two machines I've tested. Updated code to handle this case (assumes 0 offset, maybe we should do something else instead). Long term fix is obviously make an endpoint to return this timestamp. 