### PR TITLE
Fix regression in enableMicrophone

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -413,11 +413,11 @@ class JanusAdapter {
 
   enableMicrophone(enabled) {
     if (this.publisher && this.publisher.conn) {
-      for (var sender in this.publisher.conn.getSenders()) {
-        if (sender.track.kind == "audio") {
-          sender.track.enabled = enabled;
+      this.publisher.conn.getSenders().forEach(s => {
+        if (s.track.kind == "audio") {
+          s.track.enabled = enabled;
         }
-      }
+      });
     }
   }
 


### PR DESCRIPTION
I accidentally screwed this up in #21. Now it's fixed. Tested in Chrome and Firefox.