### PR TITLE
Check if sender's track is null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -414,7 +414,7 @@ class JanusAdapter {
   enableMicrophone(enabled) {
     if (this.publisher && this.publisher.conn) {
       this.publisher.conn.getSenders().forEach(s => {
-        if (s.track.kind == "audio") {
+        if (s.track != null && s.track.kind == "audio") {
           s.track.enabled = enabled;
         }
       });


### PR DESCRIPTION
Toggling microphone state is broken because some track is null. This happens when the track isn't sending anything.

https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender