### PR TITLE
Use strings to match Janus. Fixes incorrect lookup in Map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ const PEER_CONNECTION_CONFIG = {
 class JanusAdapter {
   constructor() {
     this.room = null;
-    this.userId = randomUint();
+    this.userId = String(randomUint());
 
     this.serverUrl = null;
     this.webRtcOptions = {};


### PR DESCRIPTION
This was causing a audio to drop out for random participants since there was a race condition between NAF asking for a media stream and WebRTC already having it available. If NAF asked for a stream before it was available, it would be put into the `pendingMediaRequests` Map with a key of type `Number`, but the lookup for resolution used the new `String` type client id that Janus gives us.