### PR TITLE
Dispatch events for block and unblock

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -245,6 +245,14 @@ class JanusAdapter {
         this.addOccupant(data.user_id);
       } else if (data.event == "leave" && data.room_id == this.room) {
         this.removeOccupant(data.user_id);
+      } else if (data.event == "blocked") {
+        document.body.dispatchEvent(
+          new CustomEvent("blocked", { detail: { by: data.by } })
+        );
+      } else if (data.event == "unblocked") {
+        document.body.dispatchEvent(
+          new CustomEvent("unblocked", { detail: { by: data.by } })
+        );
       }
     });
 


### PR DESCRIPTION
This fires events on the page when the adapter receives `blocked` or `unblocked` so that the client can listen for the event and then destroy the objects owned by the other user: https://github.com/mozilla/mr-social-client/pull/214/files#diff-36e9875da4ba69fe26a79e004718180cR209