### PR TITLE
Properly throw if there is an error joining a Janus room

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -356,7 +356,9 @@ class JanusAdapter {
     });
 
     if (!message.plugindata.data.success) {
-      throw message.plugindata.data.error;
+      const err = message.plugindata.data.error;
+      console.error(err);
+      throw err;
     }
 
     var initialOccupants = message.plugindata.data.response.users[this.room] || [];


### PR DESCRIPTION
This fixes an issue that was preventing detection if a room is full in Janus -- the adapter now throws the error object Janus sends back if there is an unsuccessful join attempt.