### PR TITLE
Rooms should be strings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,11 +69,7 @@ class JanusAdapter {
   setApp(app) {}
 
   setRoom(roomName) {
-    try {
-      this.room = parseInt(roomName);
-    } catch (e) {
-      throw new Error("Room must be a positive integer.");
-    }
+    this.room = roomName;
   }
 
   setWebRtcOptions(options) {


### PR DESCRIPTION
We should do this so that later we can remove support for numeric IDs on the server side.