### PR TITLE
Use reticulum.io timecheck URL for now

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ const PEER_CONNECTION_CONFIG = {
   iceServers: [{ urls: "stun:stun1.l.google.com:19302" }, { urls: "stun:stun2.l.google.com:19302" }]
 };
 
+const TIMECHECK_SERVER_URL = "https://timecheck-prod.reticulum.io/index.html";
+
 const WS_NORMAL_CLOSURE = 1000;
 
 class JanusAdapter {
@@ -526,7 +528,7 @@ class JanusAdapter {
 
     const clientSentTime = Date.now();
 
-    const res = await fetch(document.location.href, {
+    const res = await fetch(TIMECHECK_SERVER_URL, {
       method: "HEAD",
       cache: "no-cache"
     });


### PR DESCRIPTION
After struggling trying to make it so I could just set this on the NAF adapter, I basically gave up since there are no event handlers that fire after the adapter is created and before the connection starts, and no other way to pass arguments into the constructor or `connect` for the adapter. So for now anyone using `naf-janus-adapter` can just use our silly Cloudfront URL to get the clock time.