### PR TITLE
workaround headless chrome webrtc video support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -384,7 +384,12 @@ class JanusAdapter {
 
   configureSubscriberSdp(originalSdp) {
     if (!isH264VideoSupported) {
-      return originalSdp;
+      if (navigator.userAgent.indexOf("HeadlessChrome") !== -1) {
+        // HeadlessChrome (e.g. puppeteer) doesn't support webrtc video streams, so we remove those lines from the SDP.
+        return originalSdp.replace(/m=video[^]*m=/, "m=");
+      } else {
+        return originalSdp;
+      }
     }
 
     // TODO: Hack to get video working on Chrome for Android. https://groups.google.com/forum/#!topic/mozilla.dev.media/Ye29vuMTpo8


### PR DESCRIPTION
We want to use naf-janus-adapter in a headless environment to support automated bots. This PR works around a limitation with headless Chrome in [puppeteer](https://github.com/GoogleChrome/puppeteer).