### PR TITLE
Add data channel message logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -505,6 +505,10 @@ class JanusAdapter {
   onDataChannelMessage(event) {
     var message = JSON.parse(event.data);
 
+    if (debug.enabled) {
+      debug(`DC in: ${event.data}`);
+    }
+
     if(!message.dataType) return;
 
     if(this.frozen) {


### PR DESCRIPTION
If debug logging is enabled this PR will log all data channel traffic to the console. (The `debug.enabled` check is there to avoid the string interpolation unless its on.)