### PR TITLE
Fix a dumb typo in negotiating code

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -300,7 +300,9 @@ class JanusAdapter {
           var answer = conn.setRemoteDescription(jsep).then(_ => conn.createAnswer());
           var local = answer.then(a => conn.setLocalDescription(a));
           var remote = answer.then(j => handle.sendJsep(j));
-          Promise.all([local, remote]).catch(e => error("Error negotiating answer: %o", e));
+          return Promise.all([local, remote]).catch(e => error("Error negotiating answer: %o", e));
+        } else { // some other kind of event, nothing to do
+          return null;
         }
       })
     );


### PR DESCRIPTION
This was breaking a non-zero amount of the time (typically resulting in a failure to connect to one peer in the room) although it should be rarer than it is for a handle to get two offers in quick succession.