### PR TITLE
Bug/concurrent data channel setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "naf-janus-adapter",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "networked-aframe Janus network adapter",
   "main": "src/index.js",
   "license": "MPL-2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -220,8 +220,10 @@ class JanusAdapter {
     // Call the naf connectSuccess callback before we start receiving WebRTC messages.
     this.connectSuccess(this.userId);
 
-    // Add all of the initial occupants.
-    await Promise.all(this.publisher.initialOccupants.map(this.addOccupant.bind(this)));
+    for (let i = 0; i < this.publisher.initialOccupants; i++) {
+      await this.addOccupant(this.publisher.initialOccupants[i]);
+    }
+
   }
 
   onWebsocketClose(event) {


### PR DESCRIPTION
In Oculus Browser, performing the initialization of the data channel sessions in parallel can cause a crash after there is more than a few users. This serializes the setup of data channels during initial join.