### PR TITLE
Re-disable or disabled streams

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -691,14 +691,16 @@ class JanusAdapter {
       stream.getTracks().forEach(t => {
         var sender = existingSenders.find(s => s.track != null && s.track.kind == t.kind);
         if (sender != null) {
+          const wasEnabled = sender.track.enabled;
+
           if (sender.replaceTrack) {
             sender.replaceTrack(t);
-            sender.track.enabled = true;
+            sender.track.enabled = wasEnabled;
           } else {
             // replaceTrack isn't implemented in Chrome, even via webrtc-adapter.
             stream.removeTrack(sender.track);
             stream.addTrack(t);
-            t.enabled = true;
+            t.enabled = wasEnabled;
           }
           newSenders.push(sender);
         } else {


### PR DESCRIPTION
Before this PR, if you muted the mic via `enableMicrophone(false)` and then called `setLocalMediaStream(stream)` to say add a video track, the track replacement code re-enabled all the streams effectively unmuting you. I wasn't sure of the reason we previously were setting `sender.track.enabled = true` here, so perhaps this introduces a new issue, but the idea is to ensure that if the previous track was disabled we maintain that state when replacing it with a new track.