### PR TITLE
Don't enable tracks when wiring up to webrtc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -791,12 +791,10 @@ class JanusAdapter {
         if (sender != null) {
           if (sender.replaceTrack) {
             sender.replaceTrack(t);
-            sender.track.enabled = true;
           } else {
             // replaceTrack isn't implemented in Chrome, even via webrtc-adapter.
             stream.removeTrack(sender.track);
             stream.addTrack(t);
-            t.enabled = true;
           }
           newSenders.push(sender);
         } else {


### PR DESCRIPTION
When the user mutes their mic in Hubs we address it by disabling the audio track going to the peers, but the adapter code currently forces all tracks to be enabled by the end of `setLocalMediaStream`. This PR changes things to leave the enabled state as-is.