### PR TITLE
Freeze mode fixes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -628,7 +628,8 @@ class JanusAdapter {
       let data = this.getPendingData(networkId, message);
       if (!data) continue;
 
-      // Override the data type on "um" messages types, since we squash updates in storeSingleMessage.
+      // Override the data type on "um" messages types, since we extract entity updates from "um" messages into
+      // individual frozenUpdates in storeSingleMessage.
       const dataType = message.dataType === "um" ? "u" : message.dataType;
 
       this.onOccupantMessage(null, dataType, data, message.source);


### PR DESCRIPTION
This fixes removal messages for entities that are created and deleted while a user is idling in freeze/pause mode. It also guards against errors for update merges on non-standard message types (like the drawing messages in mozilla/hubs)