### PR TITLE
Only do video track workaround when replacing a video track.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -819,7 +819,7 @@ class JanusAdapter {
             // Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1576771
             if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1 && t.enabled) {
               t.enabled = false;
-              setTimeout(() => t.enabled = true, 1000);
+              this.reenableTimeout = setTimeout(() => t.enabled = true, 1000);
             }
           } else {
             // Fallback for browsers that don't support replaceTrack. At this time of this writing
@@ -844,6 +844,10 @@ class JanusAdapter {
   }
 
   enableMicrophone(enabled) {
+    if (this.reenableTimeout) {
+      clearTimeout(this.reenableTimeout);
+      this.reenableTimeout = null;
+    }
     if (this.publisher && this.publisher.conn) {
       this.publisher.conn.getSenders().forEach(s => {
         if (s.track.kind == "audio") {

--- a/src/index.js
+++ b/src/index.js
@@ -817,9 +817,9 @@ class JanusAdapter {
             await sender.replaceTrack(t);
 
             // Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1576771
-            if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1 && t.enabled) {
+            if (t.kind === "video" && t.enabled && navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
               t.enabled = false;
-              this.reenableTimeout = setTimeout(() => t.enabled = true, 1000);
+              setTimeout(() => t.enabled = true, 1000);
             }
           } else {
             // Fallback for browsers that don't support replaceTrack. At this time of this writing
@@ -844,10 +844,6 @@ class JanusAdapter {
   }
 
   enableMicrophone(enabled) {
-    if (this.reenableTimeout) {
-      clearTimeout(this.reenableTimeout);
-      this.reenableTimeout = null;
-    }
     if (this.publisher && this.publisher.conn) {
       this.publisher.conn.getSenders().forEach(s => {
         if (s.track.kind == "audio") {


### PR DESCRIPTION
Fixes one way that this bug can manifest: https://github.com/mozilla/hubs/issues/1695

We call `setLocalMediaStream` with an enabled track, disable it and create the timeout.
On scene entry we try to disable the (already disabled) track via `enableMicrophone(false)`.
The timeout function runs, re-enabling the track.

We only need the timeout when replacing video tracks, so this checks that the `kind` of the `track` is `"video"` before doing the workaround. 
