### PR TITLE
Clear left occupant list on disconnect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,7 @@ class JanusAdapter {
     clearTimeout(this.reconnectionTimeout);
 
     this.removeAllOccupants();
+    this.leftOccupants = new Set();
 
     if (this.publisher) {
       // Close the publisher peer connection. Which also detaches the plugin handle.


### PR DESCRIPTION
When there is a janus disconnect, the `leftOccupants` list was not being cleared, which led to a situation where upon reconnect, the other peers would no longer receive new subscriptions from the reconnected peer. (and hence would not be heard)
