### PR TITLE
Refactor when clients are subscribed to

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -362,12 +362,14 @@ class JanusAdapter {
   }
 
   async addOccupant(occupantId) {
+    this.pendingOccupants.add(occupantId);
+    
     const availableOccupantsCount = this.availableOccupants.length;
     if (availableOccupantsCount > AVAILABLE_OCCUPANTS_THRESHHOLD) {
       const max = Math.min(1, ((availableOccupantsCount - AVAILABLE_OCCUPANTS_THRESHHOLD) / AVAILABLE_OCCUPANTS_THRESHHOLD)) * MAX_SUBSCRIBE_DELAY;
       await randomDelay(0, max);
     }
-    this.pendingOccupants.add(occupantId);
+  
     const subscriber = await this.createSubscriber(occupantId);
     if (subscriber) {
       if(!this.pendingOccupants.has(occupantId)) {

--- a/src/index.js
+++ b/src/index.js
@@ -366,8 +366,7 @@ class JanusAdapter {
     
     const availableOccupantsCount = this.availableOccupants.length;
     if (availableOccupantsCount > AVAILABLE_OCCUPANTS_THRESHHOLD) {
-      const max = Math.min(1, ((availableOccupantsCount - AVAILABLE_OCCUPANTS_THRESHHOLD) / AVAILABLE_OCCUPANTS_THRESHHOLD)) * MAX_SUBSCRIBE_DELAY;
-      await randomDelay(0, max);
+      await randomDelay(0, MAX_SUBSCRIBE_DELAY);
     }
   
     const subscriber = await this.createSubscriber(occupantId);

--- a/src/index.js
+++ b/src/index.js
@@ -373,7 +373,7 @@ class JanusAdapter {
   removeAllOccupants() {
     this.pendingOccupants.clear();
     for (let i = this.occupantIds.length - 1; i >= 0; i--) {
-      this.removeOccupant(occupantIds[i]);
+      this.removeOccupant(this.occupantIds[i]);
     }
   }
 
@@ -888,6 +888,9 @@ class JanusAdapter {
 
         this.pendingMediaRequests.get(clientId).audio.promise = audioPromise;
         this.pendingMediaRequests.get(clientId).video.promise = videoPromise;
+
+        audioPromise.catch(e => console.warn(clientId, e));
+        videoPromise.catch(e => console.warn(clientId, e));
       }
       return this.pendingMediaRequests.get(clientId)[type].promise;
     }
@@ -897,9 +900,19 @@ class JanusAdapter {
     // Safari doesn't like it when you use single a mixed media stream where one of the tracks is inactive, so we
     // split the tracks into two streams.
     const audioStream = new MediaStream();
+    try {
     stream.getAudioTracks().forEach(track => audioStream.addTrack(track));
+
+    } catch(e) {
+      console.warn(`${clientId} setMediaStream Audio Error`, e);
+    }
     const videoStream = new MediaStream();
+    try {
     stream.getVideoTracks().forEach(track => videoStream.addTrack(track));
+
+    } catch (e) {
+      console.warn(`${clientId} setMediaStream Video Error`, e);
+    }
 
     this.mediaStreams[clientId] = { audio: audioStream, video: videoStream };
 

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 const SUBSCRIBE_TIMEOUT_MS = 15000;
 
-const AVAILABLE_OCCUPANTS_THRESHHOLD = 24;
-const MAX_SUBSCRIBE_DELAY = 3000;
+const AVAILABLE_OCCUPANTS_THRESHOLD = 5;
+const MAX_SUBSCRIBE_DELAY = 5000;
 
 function randomDelay(min, max) {
   return new Promise(resolve => {
@@ -365,7 +365,7 @@ class JanusAdapter {
     this.pendingOccupants.add(occupantId);
     
     const availableOccupantsCount = this.availableOccupants.length;
-    if (availableOccupantsCount > AVAILABLE_OCCUPANTS_THRESHHOLD) {
+    if (availableOccupantsCount > AVAILABLE_OCCUPANTS_THRESHOLD) {
       await randomDelay(0, MAX_SUBSCRIBE_DELAY);
     }
   


### PR DESCRIPTION
This update changes when clients are subscribed to. Clients that connect to the Janus server are placed in an `availableOccupants` list. At any point the application (e.g. Hubs) may call `syncOccupants` with a list of occupantId's that the application wants to connect to (in Hubs, this is provided by the Reticulum presence list) which is stored in `requestedOccupants`. Whenever a client is added to either `availableOccupants` or `requestedOccupants`, occupants are either connected to (if available in both lists) or disconnected from (if not present in either list, but currently connected to). This has the dual benefit of reducing the number of SDP negotiations in Hubs (in-room users won't connect to Lobby users and Lobby users won't connect to other Lobby users), as well as *partially* fixing the issue with avatars becoming "stuck" in the room (https://github.com/mozilla/hubs/issues/1893).

See: https://github.com/mozilla/hubs/pull/2402