### PR TITLE
reconnect if iceConnectionState is disconnected

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,24 +182,17 @@ class JanusAdapter {
 
       this.session = new mj.JanusSession(this.ws.send.bind(this.ws), { timeoutMs: 30000 });
 
-      let onOpen;
-
-      const onError = () => {
-        reject(error);
-      };
-
       this.ws.addEventListener("close", this.onWebsocketClose);
       this.ws.addEventListener("message", this.onWebsocketMessage);
 
-      onOpen = () => {
-        this.ws.removeEventListener("open", onOpen);
-        this.ws.removeEventListener("error", onError);
+      this.wsOnOpen = () => {
+        this.ws.removeEventListener("open", this.wsOnOpen);
         this.onWebsocketOpen()
           .then(resolve)
           .catch(reject);
       };
 
-      this.ws.addEventListener("open", onOpen);
+      this.ws.addEventListener("open", this.wsOnOpen);
     });
 
     return Promise.all([websocketConnection, this.updateTimeOffset()]);
@@ -224,7 +217,7 @@ class JanusAdapter {
     }
 
     if (this.ws) {
-      this.ws.removeEventListener("open", this.onWebsocketOpen);
+      this.ws.removeEventListener("open", this.wsOnOpen);
       this.ws.removeEventListener("close", this.onWebsocketClose);
       this.ws.removeEventListener("message", this.onWebsocketMessage);
       this.ws.close();

--- a/src/index.js
+++ b/src/index.js
@@ -230,6 +230,14 @@ class JanusAdapter {
       this.ws.close();
       this.ws = null;
     }
+
+    // Now that all RTCPeerConnection closed, be sure to not call
+    // reconnect() again via performDelayedReconnect if previous
+    // RTCPeerConnection was in the failed or disconnected state.
+    if (this.delayedReconnectTimeout) {
+      clearTimeout(this.delayedReconnectTimeout);
+      this.delayedReconnectTimeout = null;
+    }
   }
 
   isDisconnected() {

--- a/src/index.js
+++ b/src/index.js
@@ -525,6 +525,10 @@ class JanusAdapter {
     handle.on("event", ev => {
       var data = ev.plugindata.data;
       if (data.event == "join" && data.room_id == this.room) {
+        if (this.delayedReconnectTimeout) {
+          // Don't create a new RTCPeerConnection, all RTCPeerConnection will be closed in less than 10s.
+          return;
+        }
         this.addAvailableOccupant(data.user_id);
         this.syncOccupants();
       } else if (data.event == "leave" && data.room_id == this.room) {


### PR DESCRIPTION
This can happen on Chrome when the Wi-Fi is cut temporarily (off and back on just a second).

FYI I'm currently using a 3.0.x branch in my fork https://github.com/ILLUSION-3D/naf-janus-adapter/tree/3.0.x from the 3.0.20 tag where I have this commit and cherry-picked this commit https://github.com/ILLUSION-3D/naf-janus-adapter/commit/fbbc8e7c86d2c64a97f2216fee538f33c2bf7f0b from master.